### PR TITLE
feat: Improve `useChainState` and standardize contract loading (#50)

### DIFF
--- a/app/(routes)/providers.tsx
+++ b/app/(routes)/providers.tsx
@@ -6,6 +6,7 @@ import { ApolloNextAppProvider } from "@apollo/experimental-nextjs-app-support/s
 import { newApolloClient } from "@/app/graphql/apollo.client";
 import { wagmiConfig } from "@/app/helpers/wagmi.config";
 import { ChainStateProvider } from "../providers/chainState.provider";
+import { Celo } from "../helpers/chains";
 
 const queryClient = new QueryClient();
 
@@ -16,7 +17,7 @@ export function Providers({ children }: { children: ReactNode }) {
     <ApolloNextAppProvider makeClient={newApolloClient}>
       <WagmiProvider config={wagmiConfig}>
         <QueryClientProvider client={queryClient}>
-          <RainbowKitProvider>
+          <RainbowKitProvider initialChain={Celo}>
             <ChainStateProvider>{mounted && children}</ChainStateProvider>
           </RainbowKitProvider>
         </QueryClientProvider>

--- a/app/components/_shared/connect-button/connect-button.component.tsx
+++ b/app/components/_shared/connect-button/connect-button.component.tsx
@@ -14,6 +14,7 @@ import { useUserStore } from "@/app/store";
 import { useEffect } from "react";
 import { useChainState } from "@/app/providers/chainState.provider";
 import NumbersService from "@/app/helpers/numbers.service";
+import { formatUnits } from "viem";
 
 interface ConnectedDropdownProps extends BaseComponentProps {
   block?: boolean;
@@ -32,13 +33,8 @@ export const ConnectedDropdown = ({
   const { openChainModal } = useChainModal();
   const { openAccountModal } = useAccountModal();
 
-  const {
-    initWallet,
-    disconnectWallet,
-    isFetching,
-    isInitialized,
-    balanceMENTO,
-  } = useUserStore();
+  const { initWallet, disconnectWallet, isFetching, isInitialized } =
+    useUserStore();
 
   useEffect(() => {
     const connected = !!account && !!chain;
@@ -64,32 +60,15 @@ export const ConnectedDropdown = ({
         {chainStateReady ? (
           <div className={styles.wallet_addons}>
             <div className={styles.addon}>
-              <div className={styles.addon__title}>
-                {tokens.nativeCurrency.symbol}
-              </div>
-              <div className={styles.addon__value}>
-                {NumbersService.scaleBalance(
-                  tokens.nativeCurrency.balance,
-                  tokens.nativeCurrency.decimals,
-                )}
-              </div>
-            </div>
-            <div className={styles.addon}>
               <div className={styles.addon__title}>{tokens.mento.symbol}</div>
               <div className={styles.addon__value}>
-                {NumbersService.scaleBalance(
-                  tokens.mento.balance,
-                  tokens.mento.decimals,
-                )}
+                {formatUnits(tokens.mento.balance, tokens.mento.decimals)}
               </div>
             </div>
             <div className={styles.addon}>
               <div className={styles.addon__title}>{tokens.veMento.symbol}</div>
               <div className={styles.addon__value}>
-                {NumbersService.scaleBalance(
-                  tokens.veMento.balance,
-                  tokens.veMento.decimals,
-                )}
+                {formatUnits(tokens.veMento.balance, tokens.veMento.decimals)}
               </div>
             </div>
           </div>
@@ -121,7 +100,6 @@ export const ConnectButton = ({
       {({ account, chain, openConnectModal, mounted }) => {
         if (!mounted) return <></>;
         const connected = !!account && !!chain;
-        console.log(account);
 
         return (
           <>

--- a/app/components/create-proposal/create-proposal-preview-step/create-proposal-preview-step.component.tsx
+++ b/app/components/create-proposal/create-proposal-preview-step/create-proposal-preview-step.component.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { GovernorABI } from "@/app/abis/Governor";
+import { useContracts } from "@/app/hooks/useContracts";
 import { useCreateProposalStore } from "@/app/store";
 import { MarkdownView } from "@components/_shared";
 import Wrapper from "@components/create-proposal/wrapper/wrapper.component";
@@ -21,6 +22,7 @@ type ProposalCreateParams = {
 
 export const CreateProposalPreviewStep = () => {
   const { form } = useCreateProposalStore();
+  const contracts = useContracts();
 
   const proposal: ProposalCreateParams = useMemo(() => {
     const { title, description } =
@@ -55,7 +57,7 @@ export const CreateProposalPreviewStep = () => {
 
   const onSave = useCallback(() => {
     writeContract({
-      address: "0xc1d32e3bac67b28d31d7828c8ff160e44c37be1c",
+      address: contracts?.MentoGovernor.address as Address,
       abi: GovernorABI,
       functionName: "propose",
       args: [
@@ -67,7 +69,7 @@ export const CreateProposalPreviewStep = () => {
         JSON.stringify(proposal.metadata),
       ] as any,
     });
-  }, [writeContract, proposal]);
+  }, [writeContract, proposal, contracts?.MentoGovernor.address]);
 
   return (
     <Wrapper step={formStep} title="Preview your proposal" onSave={onSave}>

--- a/app/helpers/chains.ts
+++ b/app/helpers/chains.ts
@@ -1,54 +1,42 @@
-import { Chain, celoAlfajores } from "viem/chains";
+import { Address } from "viem";
+import { celoAlfajores } from "viem/chains";
 import { celo } from "viem/chains";
+import { addresses, ContractAddresses } from "@mento-protocol/mento-sdk";
+import { MentoChain, MentoChainContracts } from "../types";
 
-export const Celo: Chain = {
+export const Celo: MentoChain = {
   ...celo,
-  // iconUrl: "https://rainbowkit-with-celo.vercel.app/icons/celo.svg",
-  // iconBackground: "#fff",
   contracts: {
     ...celo.contracts,
-    governance: {
-      address: "0x0",
-      blockCreated: 0,
-    },
-    mento: {
-      address: "0x0",
-      blockCreated: 0,
-    },
-    locking: {
-      address: "0x0",
-      blockCreated: 0,
-    },
+    ...transformToChainContracts(addresses[celo.id]),
   },
 };
 
-export const Alfajores: Chain = {
+export const Alfajores: MentoChain = {
   ...celoAlfajores,
-  // iconUrl: "https://rainbowkit-with-celo.vercel.app/icons/alfajores.svg",
-  // iconBackground: "#fff",
   contracts: {
     ...celoAlfajores.contracts,
-    governance: {
+    ...transformToChainContracts(addresses[celoAlfajores.id]),
+    //TODO: REMOVE ME POST SUBGRAPH UPDATE PLS :'(
+    //      Here we override the MentoGovernor and Locking contract addresses
+    //      To use the versions deployed by @bowd that have proposal and have
+    //      been indexed by the subgraph.
+    //      This should be removed once the subgraph is updated and the contracts
+    //      Have been seeded with some test proposals.
+    //      See comment here:
+    //      https://github.com/mento-protocol/governance-ui/pull/50#issue-2109977351
+    MentoGovernor: {
       address: "0xc1d32e3bac67b28d31d7828c8ff160e44c37be1c",
-      blockCreated: 21963087,
     },
-    mento: {
-      address: "0xc88f553dc20fc78ce554bff97c2f4a4e5bdb0134",
-      blockCreated: 21963087,
-    },
-    locking: {
-      address: "0x8e1707307f04ec9742ad3d8e6d88ae5f506f83ca",
-      blockCreated: 21963087,
+    Locking: {
+      address: "0x8E1707307f04eC9742AD3d8e6D88AE5F506F83cA",
     },
   },
 };
 
-export const Baklava: Chain = {
+export const Baklava: MentoChain = {
   id: 62320,
   name: "Baklava",
-  // network: "Baklava Testnet",
-  // iconUrl: "https://rainbowkit-with-celo.vercel.app/icons/baklava.svg",
-  // iconBackground: "#fff",
   nativeCurrency: {
     decimals: 18,
     name: "CELO",
@@ -74,17 +62,26 @@ export const Baklava: Chain = {
   },
   testnet: true,
   contracts: {
-    governance: {
-      address: "0x0",
-      blockCreated: 0,
-    },
-    mento: {
-      address: "0x0",
-      blockCreated: 0,
-    },
-    locking: {
-      address: "0x0",
-      blockCreated: 0,
-    },
+    ...transformToChainContracts(addresses[62320]),
   },
 };
+
+/**
+ * Transforms the specified Mento contract addresses to the format used by Viem.
+ * @param contractAddresses The Mento contract addresses to be transformed.
+ * @returns Mento contract addresses in the format used by Viem.
+ */
+function transformToChainContracts(
+  contractAddresses: ContractAddresses,
+): MentoChainContracts {
+  const chainContracts: Partial<MentoChainContracts> = {};
+
+  Object.keys(contractAddresses).forEach((key) => {
+    const contractKey = key as keyof ContractAddresses;
+    chainContracts[contractKey] = {
+      address: contractAddresses[contractKey] as Address,
+    };
+  });
+
+  return chainContracts as MentoChainContracts;
+}

--- a/app/hooks/useContracts.ts
+++ b/app/hooks/useContracts.ts
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+import { useChainId, useConfig } from "wagmi";
+import { MentoChain, MentoChainContracts } from "../types";
+
+export const useContracts = (): MentoChainContracts | undefined => {
+  const config = useConfig();
+  const chainId = useChainId();
+
+  const contracts = useMemo(() => {
+    const chain = config.chains.find(
+      (chain) => chain.id === chainId,
+    ) as MentoChain;
+
+    return chain?.contracts;
+  }, [chainId, config.chains]);
+
+  return contracts;
+};

--- a/app/hooks/useProposalStates.ts
+++ b/app/hooks/useProposalStates.ts
@@ -23,6 +23,7 @@ import { Proposal, ProposalState, Scalars } from "@/app/graphql";
 import { useEffect } from "react";
 import { useReadContracts } from "wagmi";
 import { GovernorABI } from "@/app/abis/Governor";
+import { useContracts } from "./useContracts";
 
 type ProposalID = Scalars["ID"]["output"];
 type ProposalToState = Record<ProposalID, ProposalState>;
@@ -48,10 +49,10 @@ export const isStateNumber = (value: any): value is StateNumber => {
 export const useProposalStates = (
   proposals: Pick<Proposal, "proposalId">[],
 ) => {
+  const contracts = useContracts();
   const { data, isError, isLoading } = useReadContracts({
     contracts: proposals.map((proposal) => ({
-      // TODO: Add propper address
-      address: "0xc1d32e3bac67b28d31d7828c8ff160e44c37be1c",
+      address: contracts?.MentoGovernor.address,
       abi: GovernorABI,
       functionName: "state",
       args: [proposal.proposalId],

--- a/app/providers/chainState.provider.tsx
+++ b/app/providers/chainState.provider.tsx
@@ -1,165 +1,12 @@
 import { createContext, useContext, useEffect, useRef } from "react";
-import { Address, Chain, ChainContract, PublicClient, erc20Abi } from "viem";
-import { useChainId, useConfig, useAccount, usePublicClient } from "wagmi";
-import { createStore, useStore } from "zustand";
-import { immer } from "zustand/middleware/immer";
-
-interface ERC20Token {
-  symbol: string;
-  decimals: number;
-  address: Address;
-}
-
-interface NetworkToken {
-  symbol: string;
-  decimals: number;
-}
-
-type TokenWithBalance<T> = T & { balance: bigint };
-
-interface ChainStateData {
-  refreshInterval: ReturnType<typeof setInterval> | null;
-  chainId: number;
-  wallet: Address;
-  client: PublicClient | null;
-  tokens: {
-    nativeCurrency: TokenWithBalance<NetworkToken>;
-    mento: TokenWithBalance<ERC20Token>;
-    veMento: TokenWithBalance<ERC20Token>;
-  };
-  initialized: boolean;
-  ready: boolean;
-}
-
-interface ChainStateActions {
-  init: (chain: Chain, wallet: Address, client: PublicClient) => void;
-  clear: () => void;
-  refresh: () => Promise<void>;
-}
-
-type ChainState = ChainStateData & ChainStateActions;
-
-type ChainStateStore = ReturnType<typeof createChainStateStore>;
-
-const emptyNetworkTokenBalance: TokenWithBalance<NetworkToken> = {
-  symbol: "",
-  decimals: 0,
-  balance: BigInt(0),
-};
-
-const emptyErc20TokenBalance: TokenWithBalance<ERC20Token> = {
-  balance: BigInt(0),
-  symbol: "",
-  decimals: 0,
-  address: "0x",
-};
-
-const INITIAL_STATE: ChainStateData = {
-  initialized: false,
-  refreshInterval: null,
-  ready: false,
-  chainId: 0,
-  wallet: "0x000000",
-  client: null,
-  tokens: {
-    nativeCurrency: emptyNetworkTokenBalance,
-    mento: emptyErc20TokenBalance,
-    veMento: emptyErc20TokenBalance,
-  },
-};
-
-const createChainStateStore = () => {
-  return createStore<ChainState>()(
-    immer((set, get) => ({
-      ...INITIAL_STATE,
-      init: (chain: Chain, wallet: Address, client: PublicClient) => {
-        if (get().initialized === true) {
-          get().clear();
-        }
-        set((state) => {
-          return {
-            ...state,
-            wallet,
-            client,
-            initialized: true,
-            ready: false,
-            chainId: chain.id,
-            tokens: {
-              nativeCurrency: {
-                symbol: chain.nativeCurrency.symbol,
-                decimals: 18,
-                balance: BigInt(0),
-              },
-              mento: {
-                symbol: "MENTO",
-                decimals: 18,
-                address: (chain.contracts!.mento! as ChainContract).address, // TODO maybe smarter typing?
-                balance: BigInt(0),
-              },
-              veMento: {
-                symbol: "veMENTO",
-                decimals: 18,
-                address: (chain.contracts!.locking! as ChainContract).address,
-                balance: BigInt(0),
-              },
-            },
-          };
-        });
-
-        get().refresh();
-        const refreshInterval = setInterval(() => {
-          get().refresh();
-        }, 20000); // TODO: Make refresh interval configurable
-
-        set((state) => {
-          state.refreshInterval = refreshInterval;
-        });
-      },
-      refresh: async () => {
-        const client = get().client;
-        if (client === null) return;
-        const balance = await client.getBalance({
-          address: get().wallet,
-        });
-        console.log(balance);
-        set((state) => {
-          state.tokens.nativeCurrency.balance = balance;
-        });
-        const results = await client.multicall({
-          contracts: [
-            {
-              address: get().tokens.mento.address,
-              abi: erc20Abi,
-              functionName: "balanceOf",
-              args: [get().wallet],
-            },
-            {
-              address: get().tokens.veMento.address,
-              abi: erc20Abi,
-              functionName: "balanceOf",
-              args: [get().wallet],
-            },
-          ],
-        });
-        console.log(results);
-        const [mentoBalance, veMentoBalance] = results.map((result) =>
-          result.result ? result.result : BigInt(0),
-        );
-        set((state) => {
-          state.ready = true;
-          state.tokens.mento.balance = mentoBalance;
-          state.tokens.veMento.balance = veMentoBalance;
-        });
-      },
-      clear: () => {
-        const intervalId = get().refreshInterval;
-        if (intervalId !== null) {
-          clearInterval(intervalId);
-        }
-      },
-    })),
-  );
-};
+import { useChainId, useAccount, usePublicClient } from "wagmi";
+import { useStore } from "zustand";
+import { useContracts } from "../hooks/useContracts";
+import {
+  ChainState,
+  ChainStateStore,
+  createChainStateStore,
+} from "../store/chainState.store";
 
 type ChainStateProviderProps = React.PropsWithChildren<{}>;
 
@@ -170,7 +17,7 @@ export const ChainStateProvider = ({ children }: ChainStateProviderProps) => {
     storeRef.current = createChainStateStore();
   }
   const chainId = useChainId();
-  const config = useConfig();
+  const contracts = useContracts();
   const account = useAccount();
   const client = usePublicClient();
 
@@ -190,13 +37,9 @@ export const ChainStateProvider = ({ children }: ChainStateProviderProps) => {
       state.chainId !== chainId ||
       state.wallet != account.address
     ) {
-      state.init(
-        config.chains.find((c) => c.id === chainId)!,
-        account.address!,
-        client,
-      );
+      state.init(chainId, contracts!, account.address!, client);
     }
-  }, [chainId, config.chains, account, client]);
+  }, [chainId, contracts, account, client]);
 
   return (
     <ChainStateContext.Provider value={storeRef.current}>

--- a/app/store/chainState.store.tsx
+++ b/app/store/chainState.store.tsx
@@ -1,0 +1,197 @@
+import { Address, MulticallParameters, PublicClient, erc20Abi } from "viem";
+import { createStore } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { MentoChain } from "../types";
+
+interface TokenWithBalance {
+  symbol: string;
+  decimals: number;
+  address: Address;
+  balance: bigint;
+}
+
+interface ChainStateData {
+  // Internals:
+  client: PublicClient | null;
+  refreshInterval: ReturnType<typeof setInterval> | null;
+  initialized: boolean;
+  ready: boolean;
+  chainId: number;
+  wallet: Address;
+  contracts: MentoChain["contracts"] | null;
+  // State:
+  tokens: {
+    mento: TokenWithBalance;
+    veMento: TokenWithBalance;
+  };
+}
+
+interface ChainStateActions {
+  init: (
+    chainId: MentoChain["id"],
+    contracts: MentoChain["contracts"],
+    wallet: Address,
+    client: PublicClient,
+  ) => void;
+  clear: () => void;
+  load: (viewCalls: ViewCall[]) => Promise<void>;
+}
+
+export type ChainState = ChainStateData & ChainStateActions;
+
+const emptyTokenBalance: TokenWithBalance = {
+  balance: BigInt(0),
+  symbol: "",
+  decimals: 0,
+  address: "0x",
+};
+
+const INITIAL_STATE: ChainStateData = {
+  initialized: false,
+  refreshInterval: null,
+  ready: false,
+  chainId: 0,
+  wallet: "0x0",
+  client: null,
+  contracts: null,
+  tokens: {
+    mento: emptyTokenBalance,
+    veMento: emptyTokenBalance,
+  },
+};
+
+/*
+ * Interface of a ViewCall.
+ * The store has multiple view calls that are loaded and refreshed
+ * and exposed as state to the application.
+ * Centralizing them here will result in a single RCP call to a mulicall
+ * contract, instead of multiple calls to different contracts.
+ */
+interface ViewCall {
+  call: MulticallParameters["contracts"][0];
+  update: (result: any) => (state: ChainState) => void;
+  refresh: boolean;
+}
+
+/*
+ * Helper to return a balanceOf multicall getter
+ */
+const balanceOf = (token: Address, wallet: Address) => ({
+  address: token,
+  abi: erc20Abi,
+  functionName: "balanceOf",
+  args: [wallet],
+});
+
+/*
+ * This function is used to compile all view calls that will be
+ * loaded and refreshed always in the app.
+ * @dev: Add global view calls here, like the contract params.
+ */
+const compileViewCalls = (state: ChainStateData): ViewCall[] => {
+  return [
+    {
+      // $MENTO.balanceOf(wallet) -> state.tokens.mento.balance
+      call: balanceOf(state.tokens.mento.address, state.wallet),
+      update: (result: bigint) => (state: ChainState) => {
+        state.tokens.mento.balance += result;
+      },
+      refresh: true,
+    },
+    {
+      // $veMENTO.balanceOf(wallet) -> state.tokens.veMento.balance
+      call: balanceOf(state.tokens.veMento.address, state.wallet),
+      update: (result: bigint) => (state: ChainState) => {
+        state.tokens.veMento.balance += result;
+      },
+      refresh: true,
+    },
+  ];
+};
+
+export type ChainStateStore = ReturnType<typeof createChainStateStore>;
+export const createChainStateStore = () => {
+  return createStore<ChainState>()(
+    immer((set, get) => ({
+      ...INITIAL_STATE,
+      init: (
+        chainId: MentoChain["id"],
+        contracts: MentoChain["contracts"],
+        wallet: Address,
+        client: PublicClient,
+      ) => {
+        if (get().initialized === true) {
+          get().clear();
+        }
+        set((state) => {
+          return {
+            ...state,
+            wallet,
+            client,
+            initialized: true,
+            ready: false,
+            chainId: chainId,
+            contracts: contracts,
+            tokens: {
+              mento: {
+                symbol: "MENTO",
+                decimals: 18,
+                address: contracts.MentoToken.address,
+                balance: BigInt(0),
+              },
+              veMento: {
+                symbol: "veMENTO",
+                decimals: 18,
+                address: contracts.Locking.address,
+                balance: BigInt(0),
+              },
+            },
+            viewCalls: [],
+          };
+        });
+
+        const viewCalls = compileViewCalls(get());
+
+        // Initial load
+        get()
+          .load(viewCalls)
+          .then(() => {
+            set((state) => {
+              state.ready = true;
+            });
+          });
+
+        // Refresh viewCalls that are marked with refresh
+        const refreshInterval = setInterval(() => {
+          get().load(viewCalls.filter((viewCall) => viewCall.refresh === true));
+        }, 40000); // TODO: Make refresh interval configurable
+
+        set((state) => {
+          state.refreshInterval = refreshInterval;
+        });
+      },
+      load: async (viewCalls: ViewCall[]) => {
+        const client = get().client;
+        if (client === null) return;
+        const results = await client.multicall({
+          contracts: viewCalls.map((viewCall) => viewCall.call),
+        });
+        results.forEach((result, index) => {
+          if (result.status == "success") {
+            set(viewCalls[index].update(result.result));
+          } else {
+            console.error(
+              `Error fetching ${viewCalls[index].call.address}.${viewCalls[index].call.functionName}`,
+            );
+          }
+        });
+      },
+      clear: () => {
+        const intervalId = get().refreshInterval;
+        if (intervalId !== null) {
+          clearInterval(intervalId);
+        }
+      },
+    })),
+  );
+};

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -1,3 +1,7 @@
+import { ChainContract } from "viem";
+import { Chain } from "viem/chains";
+import { ContractAddresses } from "@mento-protocol/mento-sdk";
+
 export type BadgeType =
   | "primary"
   | "secondary"
@@ -17,3 +21,11 @@ export type ButtonType =
   | "info"
   | "link"
   | "clear";
+
+export type MentoChainContracts = {
+  [K in keyof ContractAddresses]: ChainContract;
+};
+
+export type MentoChain = Chain & {
+  contracts: Chain["contracts"] & MentoChainContracts;
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@apollo/experimental-nextjs-app-support": "^0.6.0",
     "@hookform/resolvers": "^3.3.2",
     "@mdxeditor/editor": "^1.11.2",
+    "@mento-protocol/mento-sdk": "^0.2.2",
     "@rainbow-me/rainbowkit": "2.0.0-beta.1",
     "@tanstack/react-query": "^5.17.10",
     "chart.js": "^4.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   '@mdxeditor/editor':
     specifier: ^1.11.2
     version: 1.14.3(@codemirror/language@6.10.0)(@lezer/common@1.2.0)(@lezer/highlight@1.2.0)(@types/react-dom@18.2.18)(@types/react@18.2.47)(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.10)
+  '@mento-protocol/mento-sdk':
+    specifier: ^0.2.2
+    version: 0.2.2(ethers@5.7.2)
   '@rainbow-me/rainbowkit':
     specifier: 2.0.0-beta.1
     version: 2.0.0-beta.1(@types/react@18.2.47)(react-dom@18.2.0)(react@18.2.0)(viem@2.0.6)(wagmi@2.2.0)
@@ -2013,6 +2016,321 @@ packages:
       micro-ftch: 0.3.1
     dev: false
 
+  /@ethersproject/abi@5.7.0:
+    resolution: {integrity: sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==}
+    dependencies:
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
+  /@ethersproject/abstract-provider@5.7.0:
+    resolution: {integrity: sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/networks': 5.7.1
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/web': 5.7.1
+    dev: false
+
+  /@ethersproject/abstract-signer@5.7.0:
+    resolution: {integrity: sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==}
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+    dev: false
+
+  /@ethersproject/address@5.7.0:
+    resolution: {integrity: sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/rlp': 5.7.0
+    dev: false
+
+  /@ethersproject/base64@5.7.0:
+    resolution: {integrity: sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+    dev: false
+
+  /@ethersproject/basex@5.7.0:
+    resolution: {integrity: sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/properties': 5.7.0
+    dev: false
+
+  /@ethersproject/bignumber@5.7.0:
+    resolution: {integrity: sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      bn.js: 5.2.1
+    dev: false
+
+  /@ethersproject/bytes@5.7.0:
+    resolution: {integrity: sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==}
+    dependencies:
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/constants@5.7.0:
+    resolution: {integrity: sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+    dev: false
+
+  /@ethersproject/contracts@5.7.0:
+    resolution: {integrity: sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==}
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+    dev: false
+
+  /@ethersproject/hash@5.7.0:
+    resolution: {integrity: sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==}
+    dependencies:
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/base64': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
+  /@ethersproject/hdnode@5.7.0:
+    resolution: {integrity: sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==}
+    dependencies:
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/basex': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/pbkdf2': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+      '@ethersproject/signing-key': 5.7.0
+      '@ethersproject/strings': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/wordlists': 5.7.0
+    dev: false
+
+  /@ethersproject/json-wallets@5.7.0:
+    resolution: {integrity: sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==}
+    dependencies:
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/hdnode': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/pbkdf2': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/random': 5.7.0
+      '@ethersproject/strings': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      aes-js: 3.0.0
+      scrypt-js: 3.0.1
+    dev: false
+
+  /@ethersproject/keccak256@5.7.0:
+    resolution: {integrity: sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      js-sha3: 0.8.0
+    dev: false
+
+  /@ethersproject/logger@5.7.0:
+    resolution: {integrity: sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==}
+    dev: false
+
+  /@ethersproject/networks@5.7.1:
+    resolution: {integrity: sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==}
+    dependencies:
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/pbkdf2@5.7.0:
+    resolution: {integrity: sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+    dev: false
+
+  /@ethersproject/properties@5.7.0:
+    resolution: {integrity: sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==}
+    dependencies:
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/providers@5.7.2:
+    resolution: {integrity: sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==}
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/base64': 5.7.0
+      '@ethersproject/basex': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/networks': 5.7.1
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/random': 5.7.0
+      '@ethersproject/rlp': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+      '@ethersproject/strings': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/web': 5.7.1
+      bech32: 1.1.4
+      ws: 7.4.6
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: false
+
+  /@ethersproject/random@5.7.0:
+    resolution: {integrity: sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/rlp@5.7.0:
+    resolution: {integrity: sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/sha2@5.7.0:
+    resolution: {integrity: sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      hash.js: 1.1.7
+    dev: false
+
+  /@ethersproject/signing-key@5.7.0:
+    resolution: {integrity: sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      bn.js: 5.2.1
+      elliptic: 6.5.4
+      hash.js: 1.1.7
+    dev: false
+
+  /@ethersproject/solidity@5.7.0:
+    resolution: {integrity: sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
+  /@ethersproject/strings@5.7.0:
+    resolution: {integrity: sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/transactions@5.7.0:
+    resolution: {integrity: sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==}
+    dependencies:
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/rlp': 5.7.0
+      '@ethersproject/signing-key': 5.7.0
+    dev: false
+
+  /@ethersproject/units@5.7.0:
+    resolution: {integrity: sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==}
+    dependencies:
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/logger': 5.7.0
+    dev: false
+
+  /@ethersproject/wallet@5.7.0:
+    resolution: {integrity: sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==}
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/hdnode': 5.7.0
+      '@ethersproject/json-wallets': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/random': 5.7.0
+      '@ethersproject/signing-key': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/wordlists': 5.7.0
+    dev: false
+
+  /@ethersproject/web@5.7.1:
+    resolution: {integrity: sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==}
+    dependencies:
+      '@ethersproject/base64': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
+  /@ethersproject/wordlists@5.7.0:
+    resolution: {integrity: sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==}
+    dependencies:
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/strings': 5.7.0
+    dev: false
+
   /@floating-ui/core@1.5.3:
     resolution: {integrity: sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q==}
     dependencies:
@@ -3282,6 +3600,20 @@ packages:
       - '@types/react-dom'
       - supports-color
       - yjs
+    dev: false
+
+  /@mento-protocol/mento-core-ts@0.2.1:
+    resolution: {integrity: sha512-p99LMVVZ7VEHgirdjgUjDH1HA9810c8z+i0EzcgTPBK8TjkGY47aV2DDWknjETcjIYfXek7V/GYhwdjeKoqEbw==}
+    dev: false
+
+  /@mento-protocol/mento-sdk@0.2.2(ethers@5.7.2):
+    resolution: {integrity: sha512-yORrxenpUqhXQeYWOa0bwbnM9aEupOokYAQcdiwGa76rkZJ43bSNM36R0qzLbnJ4Xj3xzrz8aqjp//AacLNN2Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      ethers: ^5.7
+    dependencies:
+      '@mento-protocol/mento-core-ts': 0.2.1
+      ethers: 5.7.2
     dev: false
 
   /@metamask/eth-json-rpc-provider@1.0.1:
@@ -6162,6 +6494,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  /aes-js@3.0.0:
+    resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
+    dev: false
+
   /agent-base@7.1.0:
     resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
     engines: {node: '>= 14'}
@@ -6564,6 +6900,10 @@ packages:
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  /bech32@1.1.4:
+    resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
+    dev: false
 
   /bignumber.js@9.1.2:
     resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
@@ -8129,6 +8469,44 @@ packages:
       '@noble/hashes': 1.3.1
       '@scure/bip32': 1.3.1
       '@scure/bip39': 1.2.1
+    dev: false
+
+  /ethers@5.7.2:
+    resolution: {integrity: sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==}
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/abstract-signer': 5.7.0
+      '@ethersproject/address': 5.7.0
+      '@ethersproject/base64': 5.7.0
+      '@ethersproject/basex': 5.7.0
+      '@ethersproject/bignumber': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/constants': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/hdnode': 5.7.0
+      '@ethersproject/json-wallets': 5.7.0
+      '@ethersproject/keccak256': 5.7.0
+      '@ethersproject/logger': 5.7.0
+      '@ethersproject/networks': 5.7.1
+      '@ethersproject/pbkdf2': 5.7.0
+      '@ethersproject/properties': 5.7.0
+      '@ethersproject/providers': 5.7.2
+      '@ethersproject/random': 5.7.0
+      '@ethersproject/rlp': 5.7.0
+      '@ethersproject/sha2': 5.7.0
+      '@ethersproject/signing-key': 5.7.0
+      '@ethersproject/solidity': 5.7.0
+      '@ethersproject/strings': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/units': 5.7.0
+      '@ethersproject/wallet': 5.7.0
+      '@ethersproject/web': 5.7.1
+      '@ethersproject/wordlists': 5.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: false
 
   /event-target-shim@5.0.1:
@@ -9715,6 +10093,10 @@ packages:
   /jose@5.2.0:
     resolution: {integrity: sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw==}
     dev: true
+
+  /js-sha3@0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
+    dev: false
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -12929,6 +13311,10 @@ packages:
       loose-envify: 1.4.0
     dev: false
 
+  /scrypt-js@3.0.1:
+    resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
+    dev: false
+
   /scuid@1.1.0:
     resolution: {integrity: sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==}
     dev: true
@@ -14519,6 +14905,19 @@ packages:
         optional: true
     dependencies:
       async-limiter: 1.0.1
+    dev: false
+
+  /ws@7.4.6:
+    resolution: {integrity: sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
     dev: false
 
   /ws@7.5.9:


### PR DESCRIPTION
### Description

It improves the chain state helper definition and loading and exposes a `useContracts` hook used throughout the app. The problem with this PR right now is that the addresses in the SDK are not the ones that are indexed in `The Graph` that is a separate deployment. I will migrate the indexers to this deployment as well.

After I do that, however, we will have no test proposals because the ones that I created are on the other deployment. We need a small script to seed the deployment with some test proposals that have votes. 

### Other changes

- None

### Tested

- Verified correct contract addresses were being used with logs on chain switch :)

### Related issues

-  Fixes #49