### PR TITLE
fix: correct supply in info component

### DIFF
--- a/app/(routes)/page.tsx
+++ b/app/(routes)/page.tsx
@@ -73,10 +73,7 @@ const Page = () => {
               &nbsp;CELO
             </Badge>
             <Badge rounded type="secondary">
-              ERC20
-            </Badge>
-            <Badge rounded type="secondary">
-              {(9999999998).toLocaleString()} Supply
+              MENTO {(1_000_000_000).toLocaleString()} Supply
             </Badge>
           </div>
         </div>


### PR DESCRIPTION
### Description

Small fix on the info component to display the correct token supply and remove the ERC20 pill, according to the figma design.

### Tested

Ran it locally

### Related issues

-  Fixes https://github.com/mento-protocol/governance-ui/issues/62
