### PR TITLE
fix: bread crumb colors and missing proposal id

### DIFF
--- a/app/(routes)/layout.tsx
+++ b/app/(routes)/layout.tsx
@@ -6,7 +6,7 @@ import { Footer, Header, Breadcrumbs } from "@components/_shared";
 import React, { ReactNode } from "react";
 import { Providers } from "@/app/(routes)/providers";
 import { ModalProvider } from "@/app/providers/modal.provider";
-import { usePathname } from "next/navigation";
+import { useParams, usePathname } from "next/navigation";
 
 const inter = Inter({ subsets: ["latin"] });
 

--- a/app/components/_shared/breadcrumbs/breadcrumbs.component.tsx
+++ b/app/components/_shared/breadcrumbs/breadcrumbs.component.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { routingMap } from "@/app/helpers/routing.map";
-import { usePathname } from "next/navigation";
+import { useParams, usePathname } from "next/navigation";
 import { useMemo } from "react";
+import Link from "next/link";
 import styles from "./breadcrumbs.module.scss";
 
 type CrumbProps = {
@@ -13,7 +14,7 @@ type CrumbProps = {
 const Crumb = ({ path, index, last }: CrumbProps) => {
   const crumbName = routingMap.get(path);
   const isProposalCrumb = crumbName === "Proposal";
-  const proposalId = getProposalIdFromPath(usePathname());
+  const proposalId = (useParams().id || "") as string;
 
   return (
     <li className={styles.crumb}>
@@ -26,9 +27,9 @@ const Crumb = ({ path, index, last }: CrumbProps) => {
           {isProposalCrumb && ` ${shortenProposalId(proposalId)}`}
         </span>
       ) : (
-        <a href={path || "/"} className={styles.crumb__clickable}>
+        <Link href={path || "/"} className={styles.crumb__clickable}>
           {crumbName}
-        </a>
+        </Link>
       )}
     </li>
   );
@@ -56,12 +57,6 @@ export const Breadcrumbs = () => {
     </nav>
   );
 };
-
-function getProposalIdFromPath(path: string): string {
-  const proposalPagePattern = /\/proposals\/(\d+)/;
-  const match = proposalPagePattern.exec(path)!;
-  return match ? match[1] : "";
-}
 
 function shortenProposalId(proposalId: string): string {
   return `${proposalId.slice(0, 8)}...${proposalId.slice(-4)}`;

--- a/app/components/_shared/breadcrumbs/breadcrumbs.component.tsx
+++ b/app/components/_shared/breadcrumbs/breadcrumbs.component.tsx
@@ -11,17 +11,19 @@ type CrumbProps = {
 };
 
 const Crumb = ({ path, index, last }: CrumbProps) => {
-  const pathName = routingMap[path];
+  const crumbName = routingMap.get(path);
+  const isProposalCrumb = crumbName === "Proposal";
+  const proposalId = isProposalCrumb ? shortenProposalId(getProposalIdFromPath()) : "";
 
   return (
     <li className={styles.crumb}>
-      {index > 0 && pathName && (
+      {index > 0 && crumbName && (
         <span className={styles.crumb__separator}>{">"}</span>
       )}
       {last ? (
-        <span className={styles.crumb__last}>{pathName}</span>
+        <span>{crumbName}{isProposalCrumb && ` ${proposalId}`}</span>
       ) : (
-        <a href={path || "/"}>{pathName}</a>
+        <a href={path || "/"} className={styles.crumb__clickable}>{crumbName}</a>
       )}
     </li>
   );
@@ -29,23 +31,36 @@ const Crumb = ({ path, index, last }: CrumbProps) => {
 
 export const Breadcrumbs = () => {
   const paths = usePathname().split("/");
-  const crumbPaths = useMemo(
-    () => paths.filter((path) => routingMap[path]),
+  const crumbsPath = useMemo(
+    () => paths.filter((path) => routingMap.has(path)),
     [paths],
   );
 
   return (
     <nav className={styles.container} aria-label="Breadcrumb">
       <ol>
-        {crumbPaths.map((path, index) => (
+        {crumbsPath.map((path, index) => (
           <Crumb
-            path={path}
             key={index}
+            path={path}
             index={index}
-            last={index === crumbPaths.length - 1}
+            last={index === crumbsPath.length - 1}
           />
         ))}
       </ol>
     </nav>
   );
 };
+
+function getProposalIdFromPath(): string {
+  const proposalPagePattern = /\/proposals\/(\d+)/;
+  if (!proposalPagePattern.test(usePathname())) {
+    throw new Error("Not a proposal page");
+  }
+  const match = proposalPagePattern.exec(usePathname())!;
+  return match[1]
+}
+
+function shortenProposalId(proposalId: string): string {
+  return `${proposalId.slice(0,8)}...${proposalId.slice(-4)}`;
+}

--- a/app/components/_shared/breadcrumbs/breadcrumbs.component.tsx
+++ b/app/components/_shared/breadcrumbs/breadcrumbs.component.tsx
@@ -13,7 +13,7 @@ type CrumbProps = {
 const Crumb = ({ path, index, last }: CrumbProps) => {
   const crumbName = routingMap.get(path);
   const isProposalCrumb = crumbName === "Proposal";
-  const proposalId = isProposalCrumb ? shortenProposalId(getProposalIdFromPath()) : "";
+  const proposalId = getProposalIdFromPath(usePathname());
 
   return (
     <li className={styles.crumb}>
@@ -21,9 +21,14 @@ const Crumb = ({ path, index, last }: CrumbProps) => {
         <span className={styles.crumb__separator}>{">"}</span>
       )}
       {last ? (
-        <span>{crumbName}{isProposalCrumb && ` ${proposalId}`}</span>
+        <span>
+          {crumbName}
+          {isProposalCrumb && ` ${shortenProposalId(proposalId)}`}
+        </span>
       ) : (
-        <a href={path || "/"} className={styles.crumb__clickable}>{crumbName}</a>
+        <a href={path || "/"} className={styles.crumb__clickable}>
+          {crumbName}
+        </a>
       )}
     </li>
   );
@@ -52,15 +57,12 @@ export const Breadcrumbs = () => {
   );
 };
 
-function getProposalIdFromPath(): string {
+function getProposalIdFromPath(path: string): string {
   const proposalPagePattern = /\/proposals\/(\d+)/;
-  if (!proposalPagePattern.test(usePathname())) {
-    throw new Error("Not a proposal page");
-  }
-  const match = proposalPagePattern.exec(usePathname())!;
-  return match[1]
+  const match = proposalPagePattern.exec(path)!;
+  return match ? match[1] : "";
 }
 
 function shortenProposalId(proposalId: string): string {
-  return `${proposalId.slice(0,8)}...${proposalId.slice(-4)}`;
+  return `${proposalId.slice(0, 8)}...${proposalId.slice(-4)}`;
 }

--- a/app/components/_shared/breadcrumbs/breadcrumbs.module.scss
+++ b/app/components/_shared/breadcrumbs/breadcrumbs.module.scss
@@ -18,7 +18,7 @@
       margin: 0 $theme-unit * 2;
     }
     
-    &__last {
+    &__clickable {
       color: $c-primary
     }
   }

--- a/app/helpers/routing.map.ts
+++ b/app/helpers/routing.map.ts
@@ -1,9 +1,6 @@
-interface RoutingMap {
-  [key: string]: string;
-}
-export const routingMap: RoutingMap = {
-  "": "Proposals",
-  "my-voting-power": "My Voting Power",
-  "create-proposal": "Create a proposal",
-  proposals: "Proposal",
-};
+export const routingMap: Map<string, string> = new Map([
+  ["", "Proposals"],
+  ["my-voting-power", "My Voting Power"],
+  ["create-proposal", "Create a proposal"],
+  ["proposals", "Proposal"],
+]);


### PR DESCRIPTION
### Description

Small fix on the breadcrumb component to:
1) fix the colors on the individual crumbs, as they were inverted from the figma design
2) add a short version of the proposal id when the user navigates to a specific proposal page

### Tested

Ran it locally

### Related issues

-  Fixes https://github.com/mento-protocol/governance-ui/issues/66
