### PR TITLE
feat: fix time calculation for timelock and voting period

### DIFF
--- a/src/lib/contracts/governor/useGovernanceDetails.ts
+++ b/src/lib/contracts/governor/useGovernanceDetails.ts
@@ -21,15 +21,18 @@ function convertSecondsToDays(
   return Math.floor(days);
 }
 
+function convertSecondsToMinutes(
+  durationInSeconds: string | bigint | number,
+): number {
+  const minutes = Number(durationInSeconds) / 60;
+  return Math.floor(minutes);
+}
+
 function formatParam(
-  rawParam: any,
+  result: any,
   formatter: (value: string | number | bigint) => string,
 ) {
-  if (rawParam.result !== undefined) {
-    return formatter(rawParam.result);
-  }
-
-  return null;
+  return formatter(result);
 }
 
 const useGovernanceDetails = () => {
@@ -97,7 +100,11 @@ const useGovernanceDetails = () => {
 
     return formatParam(votingPeriod, (value) => {
       const votingPeriodInSeconds = convertCeloBlocksToSeconds(value);
-      return `${convertSecondsToDays(votingPeriodInSeconds)} days`;
+      const votingPeriodInDays = convertSecondsToDays(votingPeriodInSeconds);
+      if (votingPeriodInDays < 1) {
+        return `${convertSecondsToMinutes(votingPeriodInSeconds)} minutes`;
+      }
+      return `${votingPeriodInDays} days`;
     });
   }, [votingPeriod]);
 
@@ -105,7 +112,11 @@ const useGovernanceDetails = () => {
     if (!timeLockDuration) return "-";
 
     return formatParam(timeLockDuration, (value) => {
-      return `${convertSecondsToDays(value)} days`;
+      const timeLockDurationInDays = convertSecondsToDays(value);
+      if (timeLockDurationInDays < 1) {
+        return `${convertSecondsToMinutes(value)} minutes`;
+      }
+      return `${timeLockDurationInDays} days`;
     });
   }, [timeLockDuration]);
 


### PR DESCRIPTION
This PR fixes the display of the voting period and the timelock period.
The existing code had an error with a check on the `rawParam.result !== undefined` since the input had no .result attribute, the code always returned null. 

Since the functions calling the formatParam function have their check for the param not being undefined I removed the check.

I also added a check for the period in days being 0. If that's the case the period is displayed in minutes to support our testnet setup. 

Fixes #149 