### PR TITLE
Fix(155): Voting update & My Locks page fix

### DIFF
--- a/src/app/(routes)/my-voting-power/page.tsx
+++ b/src/app/(routes)/my-voting-power/page.tsx
@@ -7,6 +7,7 @@ import useLocksByAccount from "@/lib/contracts/locking/useLocksByAccount";
 const Page = () => {
   const { address, isConnecting } = useAccount();
   const { locks, refetch } = useLocksByAccount({ account: address! });
+
   return (
     <main className="flex flex-col place-items-center">
       <h2 className="mb-4 mt-8 text-[32px]/none font-medium">

--- a/src/app/(routes)/proposals/[id]/page.tsx
+++ b/src/app/(routes)/proposals/[id]/page.tsx
@@ -67,7 +67,9 @@ const Page = ({ params }: { params: { id: string } }) => {
           <div className="flex flex-col gap-x1 md:grid md:grid-cols-7">
             <div className="md:col-span-4 md:col-start-1">
               <h1 className="text-[56px]/none font-medium">
-                {proposal.metadata.title}
+                <Suspense fallback={<Loader isCenter />}>
+                  {proposal.metadata?.title}
+                </Suspense>
               </h1>
             </div>
             <div className="md:col-span-3 md:col-start-5">
@@ -122,21 +124,30 @@ const Page = ({ params }: { params: { id: string } }) => {
           </div>
           <div className="mt-14 flex flex-col place-items-start gap-y-16 md:flex-row md:justify-between md:gap-1">
             <div className="w-full max-w-2xl flex-1">
-              <ProposalCurrentVotes proposal={proposal} className="md:mb-x6" />
+              {proposal.votes ? (
+                <ProposalCurrentVotes
+                  proposal={proposal}
+                  className="md:mb-x6"
+                />
+              ) : (
+                <Loader isCenter />
+              )}
               <div className="my-x6 md:hidden">
                 <Vote proposal={proposal} />
               </div>
               <h3 className="my-8 flex justify-center text-3xl font-medium">
                 Proposal Description
               </h3>
-              <MarkdownView markdown={proposal.metadata.description} />
+              <Suspense fallback={<Loader isCenter />}>
+                <MarkdownView markdown={proposal.metadata?.description} />
+              </Suspense>
               {proposal.calls && <ExecutionCode calls={proposal.calls} />}
             </div>
             <div className="flex flex-col gap-x11 md:max-w-[350px]">
               <div className="hidden md:block">
                 <Vote proposal={proposal} />
               </div>
-              <Participants votes={proposal.votes} />
+              {proposal.votes && <Participants votes={proposal.votes} />}
             </div>
           </div>
         </>

--- a/src/components/_icons/mento.icon.tsx
+++ b/src/components/_icons/mento.icon.tsx
@@ -19,12 +19,15 @@ const variants = cva("", {
 
 export interface IMentoIcon
   extends Omit<BaseIconProps, "backgroundColor">,
-    VariantProps<typeof variants> {}
+    VariantProps<typeof variants> {
+  logoColor?: string;
+}
 
 export const MentoIcon = ({
   width = 60,
   height = 60,
   backgroundColor = "default",
+  logoColor = "fill-mento-dark",
   className,
 }: IMentoIcon) => {
   return (
@@ -45,7 +48,7 @@ export const MentoIcon = ({
         r="31.1016"
       />
       <path
-        className="fill-mento-dark"
+        className={logoColor}
         d="M41.162 41.2452V51.5796H26.1765C17.7169 51.5796 11.4326 45.5006 11.4326 36.9899L11.4326 21.9139H21.705V34.5583C21.705 38.8136 24.3637 41.2452 28.5935 41.2452H41.162ZM21.705 21.9139V11.5796L36.6905 11.5796C45.1501 11.5796 51.4344 17.6586 51.4344 26.1693V41.2452H41.162V28.6009C41.162 24.3455 38.5033 21.9139 34.2735 21.9139H21.705Z"
       />
     </svg>

--- a/src/components/_shared/loader/loader.component.tsx
+++ b/src/components/_shared/loader/loader.component.tsx
@@ -4,14 +4,20 @@ import { cn } from "@/styles/helpers";
 interface ILoader extends IMentoIcon {
   isCenter?: boolean;
   className?: string;
+  logoColor?: string;
 }
 
-export const Loader = ({ className, isCenter, backgroundColor }: ILoader) => {
+export const Loader = ({
+  className,
+  isCenter,
+  backgroundColor,
+  logoColor,
+}: ILoader) => {
   return (
     <div className={cn("w-max", isCenter && "flex justify-center", className)}>
       <div className="relative h-x12 w-x12">
         <div className="absolute left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]">
-          <MentoIcon backgroundColor={backgroundColor} />
+          <MentoIcon logoColor={logoColor} backgroundColor={backgroundColor} />
         </div>
         <div
           className={cn(

--- a/src/components/_shared/vote-loading-state/vote-loading-state.tsx
+++ b/src/components/_shared/vote-loading-state/vote-loading-state.tsx
@@ -6,7 +6,7 @@ export const LoadingState = () => {
       <VotingCardTitle />
       <div className="mt-x2 flex flex-col gap-x3 text-center">
         <br />
-        <Loader isCenter />
+        <Loader className="w-[100%]" isCenter color="dark:fill-mento-mint" />
         <br />
       </div>
     </Card>

--- a/src/components/locks-list/locks-list.component.tsx
+++ b/src/components/locks-list/locks-list.component.tsx
@@ -15,9 +15,11 @@ export const LocksList = ({ locks, onExtend, account }: ILocksList) => {
   const sortedLocks: Lock[] = useMemo(() => {
     if (!account || locks.length === 0) return [];
 
-    return locks.sort((lockA, lockB) => {
+    if (locks.length === 1) return locks;
+
+    return locks.toSorted((lockA, lockB) => {
       if (lockA.lockCreate.length === 0 || lockB.lockCreate.length === 0)
-        return 1;
+        return 0;
 
       const aExpiration = getLockExpirationDate(
         lockA.lockCreate[0].timestamp,
@@ -29,8 +31,8 @@ export const LocksList = ({ locks, onExtend, account }: ILocksList) => {
         lockB.slope,
         lockB.cliff,
       );
-
-      return isAfter(aExpiration, bExpiration) ? 1 : -1;
+      const compareResult = isAfter(aExpiration, bExpiration) ? 1 : -1;
+      return compareResult;
     });
   }, [account, locks]);
 

--- a/src/components/locks-list/locks-list.component.tsx
+++ b/src/components/locks-list/locks-list.component.tsx
@@ -1,5 +1,5 @@
 import { addWeeks, format, isAfter, nextWednesday } from "date-fns";
-import React, { useMemo } from "react";
+import { Fragment, useMemo } from "react";
 import { Address, formatUnits } from "viem";
 import { Lock } from "@/lib/graphql/subgraph/generated/subgraph";
 import useLockCalculation from "@/lib/contracts/locking/useLockCalculation";
@@ -12,6 +12,28 @@ interface ILocksList {
 }
 
 export const LocksList = ({ locks, onExtend, account }: ILocksList) => {
+  const sortedLocks: Lock[] = useMemo(() => {
+    if (!account || locks.length === 0) return [];
+
+    return locks.sort((lockA, lockB) => {
+      if (lockA.lockCreate.length === 0 || lockB.lockCreate.length === 0)
+        return 1;
+
+      const aExpiration = getLockExpirationDate(
+        lockA.lockCreate[0].timestamp,
+        lockA.slope,
+        lockA.cliff,
+      );
+      const bExpiration = getLockExpirationDate(
+        lockB.lockCreate[0].timestamp,
+        lockB.slope,
+        lockB.cliff,
+      );
+
+      return isAfter(aExpiration, bExpiration) ? 1 : -1;
+    });
+  }, [account, locks]);
+
   return (
     <div className={`overflow-auto`}>
       <div className="mb-x2 grid grid-cols-3 items-center gap-[18px] px-x1">
@@ -19,38 +41,14 @@ export const LocksList = ({ locks, onExtend, account }: ILocksList) => {
         <LockTableTitle>veMENTO</LockTableTitle>
         <LockTableTitle>Expires on</LockTableTitle>
       </div>
-      {account &&
-        [...locks, { ...locks[0], lockId: "0" }]
-          .sort((lockA, lockB) => {
-            if (lockA.lockCreate.length === 0 || lockB.lockCreate.length === 0)
-              return 1;
-
-            const aExpiration = getLockExpirationDate(
-              lockA.lockCreate[0].timestamp,
-              lockA.slope,
-              lockA.cliff,
-            );
-            const bExpiration = getLockExpirationDate(
-              lockB.lockCreate[0].timestamp,
-              lockB.slope,
-              lockB.cliff,
-            );
-
-            return isAfter(aExpiration, bExpiration) ? 1 : -1;
-          })
-          .map((lock, index, array) => (
-            <React.Fragment key={lock.lockId}>
-              <LockEntry
-                account={account}
-                onExtend={onExtend}
-                lock={lock}
-                key={lock.lockId + index}
-              />
-              {index === array.length - 1 ? null : (
-                <div className="grid-span-[1/-1] border-b border-solid border-gray-light" />
-              )}
-            </React.Fragment>
-          ))}
+      {sortedLocks.map((lock, index, array) => (
+        <Fragment key={`lock-entry-${index}`}>
+          <LockEntry account={account} onExtend={onExtend} lock={lock} />
+          {index !== array.length - 1 ?? (
+            <div className="grid-span-[1/-1] border-b border-solid border-gray-light" />
+          )}
+        </Fragment>
+      ))}
     </div>
   );
 };
@@ -76,7 +74,6 @@ const LockTableValue = ({ children }: { children: React.ReactNode }) => {
 
 const LockEntry = ({
   lock,
-  onExtend,
 }: {
   lock: Lock;
   account: Address;

--- a/src/components/proposal-current-votes/proposal-current-votes.component.tsx
+++ b/src/components/proposal-current-votes/proposal-current-votes.component.tsx
@@ -44,9 +44,9 @@ export const ProposalCurrentVotes = ({
   }, [proposal.votes.against.total, proposal.votes.for.total, quorumNeeded]);
 
   const majoritySupport = useMemo(() => {
-    if (proposal.votes.total === 0n || proposal.votes.for.total === 0n)
-      return false;
+    if (proposal.votes.total === 0n) return false;
 
+    // TODO: change to quorum
     return (
       (proposal.votes.for.total * 100n) / proposal.votes.total >
       proposal.votes.total / 2n

--- a/src/components/vote-cast-vote/vote-confirmation.tsx
+++ b/src/components/vote-cast-vote/vote-confirmation.tsx
@@ -18,7 +18,7 @@ export const VoteConfirmation = ({
         <Loader
           isCenter
           className="w-[100%]"
-          logoColor="dark:fill-mento-cyan"
+          logoColor="fill-mento-dark dark:fill-mento-cyan"
         />
         <>
           <div className="flex flex-col items-center justify-center gap-1 text-[0.875rem]">

--- a/src/components/vote-cast-vote/vote-confirmation.tsx
+++ b/src/components/vote-cast-vote/vote-confirmation.tsx
@@ -15,7 +15,11 @@ export const VoteConfirmation = ({
       <VotingCardTitle />
       <div className="mt-x2 flex flex-col gap-x3 text-center">
         <span className="text-md">Confirm your vote</span>
-        <Loader isCenter />
+        <Loader
+          isCenter
+          className="w-[100%]"
+          logoColor="dark:fill-mento-cyan"
+        />
         <>
           <div className="flex flex-col items-center justify-center gap-1 text-[0.875rem]">
             <div className="flex items-center justify-center gap-1">

--- a/src/lib/contracts/locking/useLocksByAccount.ts
+++ b/src/lib/contracts/locking/useLocksByAccount.ts
@@ -15,8 +15,9 @@ const useLocksByAccount = ({ account }: UseLocksProps) => {
     data: { locks },
     ...rest
   } = useGetLocksSuspenseQuery({
-    queryKey: "locking-contract-hook",
-    refetchWritePolicy: "overwrite",
+    refetchWritePolicy: "merge",
+    fetchPolicy: "cache-and-network",
+    errorPolicy: "ignore",
     variables: {
       address: account,
     },


### PR DESCRIPTION
## Description

This PR resolves a data staleness issue when voting on a proposal. 

This PR additionally resolves an issue with the My Locks page, where in the event of an account not having any locks, a destructuring error would inject an empty `Partial<Lock>` which would cause  page render issues.

This is achieved by creating a block number watcher specifically when using the `useProposal` hook. This syncs the Apollo checks with the Tanstack queries.

## Related issues

- closes #155 