### PR TITLE
Fix(173): Darkmode explainer

### DIFF
--- a/src/components/_shared/loader/loader.component.tsx
+++ b/src/components/_shared/loader/loader.component.tsx
@@ -2,27 +2,41 @@ import { IMentoIcon, MentoIcon } from "@/components/_icons";
 import { cn } from "@/styles/helpers";
 
 interface ILoader extends IMentoIcon {
-  isCenter?: boolean;
   className?: string;
+  isCenter?: boolean;
   logoColor?: string;
+  borderColor?: string;
 }
 
 export const Loader = ({
   className,
   isCenter,
-  backgroundColor,
-  logoColor,
+  backgroundColor = "default",
+  borderColor,
+  logoColor = "mento-dark",
 }: ILoader) => {
+  borderColor =
+    borderColor ||
+    `before:border-${logoColor || "primary"} dark:before:border-white`;
   return (
-    <div className={cn("w-max", isCenter && "flex justify-center", className)}>
+    <div
+      className={cn(
+        "w-max",
+        isCenter && "m-auto flex justify-center",
+        className,
+      )}
+    >
       <div className="relative h-x12 w-x12">
         <div className="absolute left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]">
-          <MentoIcon logoColor={logoColor} backgroundColor={backgroundColor} />
+          <MentoIcon
+            logoColor={`fill-${logoColor} dark:fill-white`}
+            backgroundColor={backgroundColor}
+          />
         </div>
         <div
           className={cn(
             "relative h-x12 w-x12 animate-altSpin rounded-[50%] [animation-fill-mode:forwards]",
-            "before:absolute before:inset-0 before:animate-loaderPulseBorder before:rounded-[50%] before:border-[5px] before:border-primary",
+            `${borderColor} before:absolute before:inset-0 before:animate-loaderPulseBorder before:rounded-[50%] before:border-[2px]`,
           )}
         />
       </div>

--- a/src/components/_shared/modal/modal.component.tsx
+++ b/src/components/_shared/modal/modal.component.tsx
@@ -1,5 +1,5 @@
-import { Fragment } from "react";
 import { Dialog, Transition } from "@headlessui/react";
+import { Fragment } from "react";
 
 export interface IModal {
   isOpen: boolean;
@@ -40,7 +40,7 @@ export const Modal = ({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-lg bg-white px-12 py-7 align-middle shadow-xl transition-all dark:bg-mento-dark">
+              <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-lg bg-white px-12 py-7 align-middle shadow-xl transition-all dark:border dark:border-gray-light dark:bg-mento-dark">
                 <Dialog.Title
                   as="h3"
                   className="text-center text-3xl font-medium text-gray-900 dark:text-white"

--- a/src/components/_shared/modal/modal.component.tsx
+++ b/src/components/_shared/modal/modal.component.tsx
@@ -40,10 +40,10 @@ export const Modal = ({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-lg bg-white px-12 py-7 align-middle shadow-xl transition-all">
+              <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-lg bg-white px-12 py-7 align-middle shadow-xl transition-all dark:bg-mento-dark">
                 <Dialog.Title
                   as="h3"
-                  className="text-center text-3xl font-medium text-gray-900"
+                  className="text-center text-3xl font-medium text-gray-900 dark:text-white"
                 >
                   {title}
                 </Dialog.Title>

--- a/src/components/_shared/step-counter/step-counter.component.tsx
+++ b/src/components/_shared/step-counter/step-counter.component.tsx
@@ -8,7 +8,7 @@ export const StepCounter = ({ children, className }: StepCounterProps) => {
   return (
     <div
       className={cn(
-        "relative flex h-x5 w-x5 items-center justify-center rounded-t-[4px] bg-inherit",
+        "relative flex h-x5 w-x5 items-center justify-center rounded-t-[4px] bg-inherit pb-[1px] pr-[1px]",
         className,
       )}
     >

--- a/src/components/_shared/tx-modal/tx-modal.component.tsx
+++ b/src/components/_shared/tx-modal/tx-modal.component.tsx
@@ -18,7 +18,7 @@ export const TxModal = ({
 }: ITxModal) => {
   return (
     <Modal isOpen={isOpen} title={title}>
-      <div className="mt-2">
+      <div className="dark mt-2">
         {error ? <ErrorMessage /> : <PendingMessage message={message} />}
       </div>
       {error && (
@@ -49,8 +49,11 @@ const ErrorMessage = () => {
 const PendingMessage = ({ message }: { message: React.ReactNode }) => {
   return (
     <>
-      <div className="text-lg text-primary-dark">{message}</div>
-      <Loader className="mx-auto my-8" />
+      <div className="text-lg text-primary-dark dark:text-white">{message}</div>
+      <Loader
+        logoColor="fill-mento-dark dark:fill-mento-cyan"
+        className="mx-auto my-8"
+      />
     </>
   );
 };

--- a/src/components/_shared/tx-modal/tx-modal.component.tsx
+++ b/src/components/_shared/tx-modal/tx-modal.component.tsx
@@ -50,6 +50,7 @@ const PendingMessage = ({ message }: { message: React.ReactNode }) => {
     <>
       <p className="text-lg text-primary-dark dark:text-white">{message}</p>
       <Loader
+        borderColor="before:border-mento-dark dark:before:border-mento-cyan"
         logoColor="fill-mento-dark dark:fill-mento-cyan"
         className="mx-auto my-8"
       />

--- a/src/components/_shared/tx-modal/tx-modal.component.tsx
+++ b/src/components/_shared/tx-modal/tx-modal.component.tsx
@@ -18,7 +18,7 @@ export const TxModal = ({
 }: ITxModal) => {
   return (
     <Modal isOpen={isOpen} title={title}>
-      <div className="dark mt-2">
+      <div className="mt-2">
         {error ? <ErrorMessage /> : <PendingMessage message={message} />}
       </div>
       {error && (
@@ -38,10 +38,9 @@ export const TxModal = ({
 const ErrorMessage = () => {
   return (
     <>
-      <p className="text-center text-lg text-primary-dark">
-        Unfortunately, transaction was rejected.
+      <p className="text-center text-lg text-error dark:text-error-light">
+        Transaction was rejected.
       </p>
-      {/* <MentoIcon className="mx-auto my-8" /> */}
     </>
   );
 };
@@ -49,7 +48,7 @@ const ErrorMessage = () => {
 const PendingMessage = ({ message }: { message: React.ReactNode }) => {
   return (
     <>
-      <div className="text-lg text-primary-dark dark:text-white">{message}</div>
+      <p className="text-lg text-primary-dark dark:text-white">{message}</p>
       <Loader
         logoColor="fill-mento-dark dark:fill-mento-cyan"
         className="mx-auto my-8"

--- a/src/components/create-proposal/explainer-modal/execution-explainer.modal.tsx
+++ b/src/components/create-proposal/explainer-modal/execution-explainer.modal.tsx
@@ -23,7 +23,7 @@ export const ExecutionExplanationModal = ({
       onClose={onClose}
       title="The execution code must follow these rules:"
     >
-      <div className="mx-auto">
+      <div className="mx-auto dark:bg-mento-dark">
         <ul className="mx-auto ml-3 mt-2 flex list-disc flex-col items-start gap-1 text-left font-light">
           <li className=" ">It must be a valid JSON array.</li>
           <li className=" ">


### PR DESCRIPTION
## Description 

This PR updates the modal to use the typical dark mode colors 

## Testing

Basically switch to dark mode, go to create proposal, check the explainer modal on the code section in step 3

Then try create a proposal, but dont sign the transaction, check if the loading modal is correct, then decline signing the create proposal transaction, and see if the retry modal is correct as well

## Related issues 

- closes #173