### PR TITLE
fix: join discord button width

### DIFF
--- a/src/components/_shared/learn-more/learn-more.component.tsx
+++ b/src/components/_shared/learn-more/learn-more.component.tsx
@@ -26,11 +26,11 @@ export const LearnMore = ({ className, style }: LearnMoreProps) => {
                 contribute, please join our discord server.
               </p>
               <Button
-                className="mt-x4 w-full max-w-full"
+                className="mt-x4 w-full max-w-full sm:mx-auto sm:block sm:max-w-[200px] lg:mx-0 lg:inline-block"
                 href="https://discord.gg"
                 target="_blank"
               >
-                <div className="flex items-center gap-x2 px-x3 sm:w-full">
+                <div className="flex items-center gap-x2 px-x3">
                   <DiscordIcon />
                   <span>Join the community</span>
                   <ChevronIcon direction="right" />


### PR DESCRIPTION
### Description

Minor fix to correct width of discord join button. 

### Related issues

- Closes #208 


Before:
![image](https://github.com/user-attachments/assets/51caa327-6b69-4217-a761-c016a9c2ebe5)


After:
![image](https://github.com/user-attachments/assets/f12f5a50-41c1-457b-9a2f-ca738f1e0459)

