### PR TITLE
Change "Voters" to "Registered Voters" in Proposal Summary section on landing page

### DIFF
--- a/.secretlintignore
+++ b/.secretlintignore
@@ -1,3 +1,4 @@
+.trunk
 .env*.local
 .next
 node_modules

--- a/src/components/proposal-summary/proposal-summary.component.tsx
+++ b/src/components/proposal-summary/proposal-summary.component.tsx
@@ -1,18 +1,18 @@
+import { Card } from "@/components/_shared";
+import useProposals from "@/lib/contracts/governor/useProposals";
+import useAllLocks from "@/lib/contracts/locking/useAllLocks";
+import useLockingWeek from "@/lib/contracts/locking/useLockingWeek";
+import useTokens from "@/lib/contracts/useTokens";
+import { ensureChainId } from "@/lib/helpers/ensureChainId";
+import NumbersService from "@/lib/helpers/numbers.service";
 import { Suspense, useMemo } from "react";
 import { formatUnits } from "viem";
 import { useAccount, useBlockNumber } from "wagmi";
-import { Card } from "@/components/_shared";
-import useProposals from "@/lib/contracts/governor/useProposals";
-import useLockingWeek from "@/lib/contracts/locking/useLockingWeek";
-import useAllLocks from "@/lib/contracts/locking/useAllLocks";
-import useTokens from "@/lib/contracts/useTokens";
-import NumbersService from "@/lib/helpers/numbers.service";
-import { ensureChainId } from "@/lib/helpers/ensureChainId";
 
 export const ProposalSummaryComponent = () => {
   return (
     <Card className="mt-8" block>
-      <div className="grid grid-cols-2 items-start justify-between gap-x6 pb-5 pt-4 md:grid-cols-4 md:pb-8">
+      <div className="grid grid-cols-2 items-start justify-between gap-x6 pb-4 pt-4 md:grid-cols-4">
         <Suspense fallback={<ContractDataGridSkeleton />}>
           <ContractDataGrid />
         </Suspense>
@@ -73,7 +73,7 @@ const ContractDataGrid = () => {
     <>
       <ContractData value={proposalCount} label="Total Proposals" />
       <ContractData value={activeProposalCount} label="Active Proposals" />
-      <ContractData value={getActiveVoters} label="Voters" />
+      <ContractData value={getActiveVoters} label="Registered Voters" />
       <ContractData
         value={getTotalSupplyParsed}
         label="Total veMento Voting Power"
@@ -91,15 +91,16 @@ const ContractData = ({
   isLoading?: boolean;
 }) => {
   return (
-    <div className="flex flex-col items-center justify-center gap-2 text-center md:gap-4">
+    <div className="flex flex-col items-center justify-center gap-1 text-center md:gap-2">
       <div className="text-[22px] font-medium md:text-[32px]">{value}</div>
-      <div className="max-w-32 text-[18px]">{label}</div>
+      <div className="text-[18px]">{label}</div>
     </div>
   );
 };
+
 const ContractDataSkeleton = ({ label }: { label: string }) => {
   return (
-    <div className="flex flex-col items-center justify-center gap-2 text-center md:gap-4">
+    <div className="flex flex-col items-center justify-center gap-1 text-center md:gap-2">
       <div className=" animate-pulse rounded-[4px] bg-gray-300 text-[22px] font-medium md:text-[32px]">
         <span className="opacity-0">000</span>
       </div>
@@ -113,7 +114,7 @@ const ContractDataGridSkeleton = () => {
     <>
       <ContractDataSkeleton label="Total Proposals" />
       <ContractDataSkeleton label="Active Proposals" />
-      <ContractDataSkeleton label="Voters" />
+      <ContractDataSkeleton label="Registered Voters" />
       <ContractDataSkeleton label="Total veMento Voting Power" />
     </>
   );

--- a/src/components/proposals-list/proposals-list.component.tsx
+++ b/src/components/proposals-list/proposals-list.component.tsx
@@ -1,22 +1,21 @@
 "use client";
+import { ProgressBar, Status } from "@/components/_shared";
+import useProposals from "@/lib/contracts/governor/useProposals";
+import { Proposal } from "@/lib/graphql/subgraph/generated/subgraph";
 import NumbersService from "@/lib/helpers/numbers.service";
 import StringService from "@/lib/helpers/string.service";
 import BaseComponentProps from "@/lib/interfaces/base-component-props.interface";
-import { ProgressBar, Status } from "@/components/_shared";
-import Link from "next/link";
 import { stateToStatusColorMap } from "@/lib/interfaces/proposal.interface";
+import Link from "next/link";
 import { formatUnits } from "viem";
-import useProposals from "@/lib/contracts/governor/useProposals";
-import { Proposal } from "@/lib/graphql/subgraph/generated/subgraph";
-import { EmptyProposals } from "../_icons";
-import { MentoIcon } from "../_icons";
+import { EmptyProposals, MentoIcon } from "../_icons";
 
 interface ProposalsListProps extends BaseComponentProps {}
 
 export const ProposalsListComponent = ({ className }: ProposalsListProps) => {
   return (
     <div className={`w-full font-fg ${className}`}>
-      <h2 className="pb-[32px] pt-[30px] text-center text-[22px] font-medium md:pb-[34px] md:pt-[76px]">
+      <h2 className="pb-[32px] pt-[30px] text-center text-[22px] font-medium md:pb-[30px] md:pt-[60px]">
         Proposals
       </h2>
       <ProposalsTable />

--- a/src/components/proposals-list/proposals-list.component.tsx
+++ b/src/components/proposals-list/proposals-list.component.tsx
@@ -15,7 +15,7 @@ interface ProposalsListProps extends BaseComponentProps {}
 export const ProposalsListComponent = ({ className }: ProposalsListProps) => {
   return (
     <div className={`w-full font-fg ${className}`}>
-      <h2 className="pb-[32px] pt-[30px] text-center text-[22px] font-medium md:pb-[30px] md:pt-[60px]">
+      <h2 className="pb-[32px] pt-[30px] text-center text-[32px] font-medium md:pt-[56px]">
         Proposals
       </h2>
       <ProposalsTable />


### PR DESCRIPTION
Implementing our decision-by-poll on this little naming change: 

<img width="410" alt="image" src="https://github.com/user-attachments/assets/f1d2bd5f-9895-4799-9222-16d5bda6c6b0">

Also fine-tuned some spacings around the proposal summary component.

### How to review
- [ ] Check that the string was changed on [the preview deployment](https://governance-ui-git-feat-registered-voters-strin-74c304-mentolabs.vercel.app/)
- [ ] Check that the new spacings look good on all breakpoints
- [ ] Check the code