### PR TITLE
Fix: Proposal page error handling

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Button } from "@/components/_shared";
+import { links } from "@/lib/constants/links";
+import * as Sentry from "@sentry/nextjs";
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error, reset]);
+
+  const pathname = usePathname();
+  const isHome = pathname === "/";
+
+  return (
+    <html>
+      <body className="flex h-screen flex-col items-center justify-center gap-12 dark:bg-black">
+        <div className="flex flex-col items-center justify-center">
+          <h1 className="font-fg text-7xl font-bold">Error</h1>
+          <p className="font-fg text-3xl">Oops, something went wrong!</p>
+        </div>
+        <Button
+          onClick={() => {
+            if (isHome) {
+              window.location.reload();
+            }
+            window.location.replace("/");
+          }}
+        >
+          {isHome ? "Refresh" : "Return to Home"}
+        </Button>
+        <div className="flex flex-col items-center justify-center">
+          <span className="block text-lg">
+            If this problem persists please contact the Mento Labs support
+          </span>
+          <a href={links.discord} className="text-mento-blue underline">
+            Contact Support
+          </a>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,18 +1,24 @@
 "use client";
 
 import * as Sentry from "@sentry/nextjs";
-import Error from "next/error";
+import NextError from "next/error";
 import { useEffect } from "react";
 
-export default function GlobalError({ error }) {
+export default function GlobalError({
+  error,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
   useEffect(() => {
+    console.log(error);
     Sentry.captureException(error);
   }, [error]);
 
   return (
     <html>
       <body>
-        <Error />
+        <NextError statusCode={0} />
       </body>
     </html>
   );

--- a/src/lib/contracts/governor/useProposal.ts
+++ b/src/lib/contracts/governor/useProposal.ts
@@ -7,12 +7,12 @@ import {
 import { useContracts } from "@/lib/contracts/useContracts";
 import {
   Proposal,
-  useGetProposalSuspenseQuery,
+  useGetProposalQuery,
 } from "@/lib/graphql/subgraph/generated/subgraph";
 import { useEnsureChainId } from "@/lib/hooks/useEnsureChainId";
 import { NetworkStatus } from "@apollo/client";
-import { useEffect, useMemo } from "react";
-import { useBlockNumber, useReadContract } from "wagmi";
+import { useMemo } from "react";
+import { useReadContract } from "wagmi";
 import { CELO_BLOCK_TIME } from "@/config/config.constants";
 export const ProposalQueryKey = "proposal";
 
@@ -20,34 +20,26 @@ const useProposal = (proposalId: bigint) => {
   const contracts = useContracts();
   const ensuredChainId = useEnsureChainId();
 
-  const { data: blockNumber } = useBlockNumber({
-    watch: true,
-    chainId: ensuredChainId,
-  });
-
   const {
-    data: { proposals: graphProposals },
+    data: { proposals: graphProposals } = { proposals: [] },
     networkStatus: graphNetworkStatus,
-    refetch: graphRefetch,
-  } = useGetProposalSuspenseQuery({
+  } = useGetProposalQuery({
     context: {
       apiName: getSubgraphApiName(ensuredChainId),
     },
     refetchWritePolicy: "merge",
-    fetchPolicy: "cache-and-network",
-    errorPolicy: "ignore",
-    queryKey: ProposalQueryKey,
+    initialFetchPolicy: "network-only",
+    nextFetchPolicy: "cache-and-network",
     variables: {
       id: proposalId.toString(),
     },
   });
 
-  const { data: chainData, refetch } = useReadContract({
+  const { data: chainData } = useReadContract({
     address: contracts.MentoGovernor.address,
     abi: GovernorABI,
     functionName: "state",
     args: [proposalId],
-    scopeKey: ProposalQueryKey,
     chainId: ensuredChainId,
     query: {
       refetchInterval: CELO_BLOCK_TIME,
@@ -68,16 +60,6 @@ const useProposal = (proposalId: bigint) => {
       state: STATE_FROM_NUMBER[chainData],
     };
   }, [chainData, graphProposals]);
-
-  useEffect(() => {
-    if (blockNumber) {
-      graphRefetch({
-        id: proposalId.toString(),
-      }).then(() => {
-        refetch();
-      });
-    }
-  }, [blockNumber, graphRefetch, proposalId, refetch]);
 
   return {
     proposal,

--- a/src/lib/contracts/useTokens.ts
+++ b/src/lib/contracts/useTokens.ts
@@ -1,9 +1,8 @@
 "use client";
-import { useAccount, useBlockNumber, useReadContracts } from "wagmi";
+import { useAccount, useReadContracts } from "wagmi";
 import { useContracts } from "@/lib/contracts/useContracts";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { erc20Abi } from "viem";
-import { useQueryClient } from "@tanstack/react-query";
 import { formatUnitsWithRadix } from "@/lib/helpers/numbers.service";
 import { useEnsureChainId } from "@/lib/hooks/useEnsureChainId";
 import { CELO_BLOCK_TIME } from "@/config/config.constants";
@@ -22,13 +21,8 @@ export const useTokens = () => {
   } = useContracts();
 
   const { isConnected, address } = useAccount();
-  const queryClient = useQueryClient();
-  const ensuredChainId = useEnsureChainId();
 
-  const { data: blockNumber } = useBlockNumber({
-    watch: true,
-    chainId: ensuredChainId,
-  });
+  const ensuredChainId = useEnsureChainId();
 
   const { data: tokenData, isSuccess } = useReadContracts({
     allowFailure: false,
@@ -135,7 +129,6 @@ export const useTokens = () => {
     data: balanceData,
     isSuccess: balanceFetchSuccess,
     isLoading: isBalanceLoading,
-    queryKey,
   } = useReadContracts({
     allowFailure: false,
     contracts: [
@@ -217,11 +210,6 @@ export const useTokens = () => {
     veMentoContractData.decimals,
     veMentoContractData.symbol,
   ]);
-
-  useEffect(() => {
-    queryClient.invalidateQueries({ queryKey });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blockNumber, queryClient]);
 
   return {
     isBalanceLoading,


### PR DESCRIPTION
### Description

This PR fixes an issue where the proposal page crashes randomly, often after some time on the page. This crashing behavior was caused by an error thrown within an external library. Three main things contributed to this. 

- The library we were using to query the graph (Apollo) threw an unhandled error in the proposal fetching hook
- We didn't have a global error page to catch these unhandled errors
- We were polling the graph too many times, which caused the graph to throttle us

I've added an error page to catch any unhandled errors like this & made changes to poll less & read from the cache more often. We should also look at our subgraph to see if we can increase the request limit

**For Reviewers**

You can replicate the error by visiting the [governance site](https://governance.mento.org) & opening several tabs, which will result in a crash. When you visit the deployment for this fix and perform the same test, we shouldn't have that problem now. There's also a button at the bottom of the proposal page which you can use to trigger an error to have a look at the error page, once this is reviewed we'll remove it before we merge this.

### Other changes

Added a global error page to help users reset the app instead of the black crash screen that was displayed before

### Tested

I opened several tabs on the preview and didn't experience a crash.

### Related issues

- Fixes #243 
