### PR TITLE
chore: use cachev4

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           version: 8
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/pnpm-yarn.lock') }}


### PR DESCRIPTION
### Description
cache v2 is deprecated and causing ci to fail. this pr upgrades cache action to v4
